### PR TITLE
Make Badge fields optional in types.py

### DIFF
--- a/nonebot_plugin_vrchat/vrchat/types.py
+++ b/nonebot_plugin_vrchat/vrchat/types.py
@@ -170,14 +170,14 @@ class LimitedUserModel(BaseModel):
 class Badge(BaseModel):
     """徽章"""
 
-    assigned_at: datetime
+    assigned_at: Optional[datetime] = None
     badge_description: str
     badge_id: str
     badge_image_url: str
     badge_name: str
-    hidden: bool
+    hidden: Optional[bool] = None
     showcased: bool
-    updated_at: datetime
+    updated_at: Optional[datetime] = None
 
 
 class UserModel(BaseModel):


### PR DESCRIPTION
vrc的api貌似部分用户返回的徽章数据其中有几个值会为null导致插件不能正常加载详细的用户数据

把目前已知受影响的字段改成Optional了，如果没有返回值就是none