### PR TITLE
修复group部分字段返回null和sdk返回的实例问题

### DIFF
--- a/nonebot_plugin_vrchat/vrchat/groups.py
+++ b/nonebot_plugin_vrchat/vrchat/groups.py
@@ -65,11 +65,7 @@ async def get_group(client: ApiClient, group_id: str) -> GroupModel:
         "Awaitable[dict]",
         run_sync(api.get_group)(group_id=group_id),
     )
-    return (
-        GroupModel(**result)
-        if isinstance(result, dict)
-        else GroupModel.model_validate({})
-    )
+    return GroupModel(**result.to_dict())
 
 
 async def create_group(

--- a/nonebot_plugin_vrchat/vrchat/types.py
+++ b/nonebot_plugin_vrchat/vrchat/types.py
@@ -254,10 +254,10 @@ class GroupGalleryModel(BaseModel):
     gallery_id: str = Field(alias="id")
     name: str
     description: str
-    role_ids_to_view: List[str]
-    role_ids_to_submit: List[str]
-    role_ids_to_auto_approve: List[str]
-    role_ids_to_manage: List[str]
+    role_ids_to_view: Optional[List[str]] = None
+    role_ids_to_submit: Optional[List[str]] = None
+    role_ids_to_auto_approve: Optional[List[str]] = None
+    role_ids_to_manage: Optional[List[str]] = None
     created_at: "datetime"
     updated_at: "datetime"
 
@@ -272,17 +272,17 @@ class GroupMyMemberModel(BaseModel):
     user_id: str
     role_ids: List[str]
     m_role_ids: List[str]
-    manager_notes: str
-    membership_status: str
-    visibility: str
-    joined_at: "datetime"
-    created_at: "datetime"
+    manager_notes: Optional[str] = None
+    membership_status: Optional[str] = None
+    visibility: Optional[str] = None
+    joined_at: Optional["datetime"] = None
+    created_at: Optional["datetime"] = None
     permissions: List[str]
 
     accepted_by_id: Optional[str] = None
     accepted_by_display_name: Optional[str] = None
     is_subscribed_to_announcements: bool = True
-    is_subscribed_to_event_announcements: bool = False
+    is_subscribed_to_event_announcements: Optional[bool] = None
     is_representing: bool = False
     has2_fa: bool = False
     has_joined_from_purchase: bool = False
@@ -324,10 +324,10 @@ class GroupModel(BaseModel):
     tags: List[str]
     galleries: List[GroupGalleryModel]
     created_at: "datetime"
-    updated_at: "datetime"
+    updated_at: Optional["datetime"] = None
     online_member_count: int
     my_member: GroupMyMemberModel
-    roles: List[GroupRoleModel]
+    roles: Optional[List[GroupRoleModel]] = None
 
     privacy: GroupPrivacyType = "default"
     is_verified: bool = False


### PR DESCRIPTION
貌似vrc的api还有更多的字段会返回null，改为声明Optional了，如果没有返回字段就为none

在`group.py`内的`api.get_group()`sdk返回的是对象实例而不是`dict`，用 `result.to_dict()` 将对象转换为字典来修复这个问题